### PR TITLE
^ Bug fix for batch date update and record effective date

### DIFF
--- a/do-tests.js
+++ b/do-tests.js
@@ -1,0 +1,32 @@
+var util = require('mis-util');
+var config = require('./config.ignore');
+
+var options = {
+   sysname: config.sysname,
+   webname: config.webname,
+   connect: {
+      host: config.host,
+      user: config.name,
+      password: config.user
+   },
+   cron: {
+      user: config.cronname,
+      pass: config.cron
+   },
+   view_path: {
+      local: './view/',
+      remote: '/CUST/forms/'
+   },
+   parm_path: {
+      local: './build/'
+   },
+   usc_path: {
+      local: './uScript/'
+   }
+};
+
+var mis = util(options);
+
+//test with a fake client
+mis.script.runonce('./tests/lib-batch-test.usc',['000100']);
+

--- a/tests/lib-batch-test.usc
+++ b/tests/lib-batch-test.usc
@@ -29,7 +29,7 @@ compcode = 100
 batchno = "T1"
 trans_date = $today
 transcount = 123
-userid = "A0001"
+userid = "BATCH"
 
 client_careid = "000123456"
 client_last = "FAKERSON"
@@ -37,8 +37,14 @@ client_sufx = "SR"
 client_first = "FAKIE"
 client_middle = "MAC"
 
+$trace("on,path", "/c1/FRSH/SCRIPT/S/batch.trace")
 batch = lib-dx:getDxBatchTrans(rec, asofdate, compcode, batchno, trans_date, transcount, userid,
    client, client_careid, client_last, client_sufx, client_first, client_middle)
+
+rc = $putfile(batch, "/c1/FRSH/SCRIPT/S/batch.test")
+
+lib-dx:markAsBatched(client, $today, rec)
+$trace("off")
 
 'batch = $replace(x"a0", "{br}", batch)
 
@@ -46,7 +52,6 @@ batch = lib-dx:getDxBatchTrans(rec, asofdate, compcode, batchno, trans_date, tra
 '$tag(batch)
 '$sendform()
 
-rc = $putfile(batch, "/c1/FRSH/SCRIPT/S/batch.test")
 
 rc = $unloadlib(lib-dx)
 

--- a/uScript/lib_DX10.usc
+++ b/uScript/lib_DX10.usc
@@ -418,6 +418,7 @@ private dynamic function fillclientdx(dx_rec, dx_date, dx_time, dx_primary, dx_r
 
  'dx_rec = $castn(c.dx10.rh)
  dx_rec = c.dx10.rh[uid]
+ dx_rec[effd] = c.dx10.rh[effd]
  dx_date = c.dx10.dt
  dx_time = c.dx10.time
  dx_primary = c.dx10.pimary.ax
@@ -765,6 +766,7 @@ public dynamic function MarkAsBatched(client_id, batchdate, record) is i
   MarkAsBatched = 99
   return
  endif
+ c.dx10.rh[effd] = record[effd]
  c.dx10.caredt = batchdate
  $dblock()
  MarkAsBatched = $dbupdateuid(record, 2, client_id, c.dx10.rh, c.dx10.caredt)


### PR DESCRIPTION
   : Issue : reported by tim
      the `markasbatched` function updates the record effective date with whatever the system global effective date was set to at the time. This can cause layer reordering which is undesired and can cause issues with the top layer not being the most recent record
   : fix : update private function `fillclientdx` to set the effective date of the uid variable to the effective date of the record that is being filled (dx_rec).
      update `markasbatched` to set the effective date of the record to the effective date of the uid variable that was set and updated by `fillclientdx` or manually by the calling script using the record[effd] syntax.
modified:   uScript/lib_DX10.usc
- tests for testing the batch output
  new file:   do-tests.js
  modified:   tests/lib-batch-test.usc
